### PR TITLE
Hide the now geo element when not necessary

### DIFF
--- a/thermostat-pro-timeline.js
+++ b/thermostat-pro-timeline.js
@@ -7647,6 +7647,9 @@ class ThermostatTimelineCard extends HTMLElement {
           const contentW = rowsEl.clientWidth - pl - pr;
           const leftPx = pl + (nowMin / 1440) * contentW;
           nowEl.style.left = leftPx + 'px';
+          // Set visibility of this NowGeo elt depending on the selected day key
+          const selectedDKIsToday = String(this._weekdaysViewDayKey || '').toLowerCase() === this._todayKey();
+          nowEl.style.visibility = selectedDKIsToday ? "visible" : "hidden";
         } catch {}
       };
 


### PR DESCRIPTION
Added some logic to hide the now geo div when the selected day is not today, to avoid confusion.