### PR TITLE
Fixed label for the 'one_room_all_days' view mode 

### DIFF
--- a/thermostat-pro-timeline.js
+++ b/thermostat-pro-timeline.js
@@ -6610,7 +6610,7 @@ class ThermostatTimelineCard extends HTMLElement {
                 ? this._config.weekdays_selected_room
                 : (ents[0]||'');
               const roomLabel = this._config?.labels?.[roomEid] || this._prettyName(roomEid);
-              label = `${dayName} - ${roomLabel}`.trim();
+              label = `${roomLabel}`.trim();
             } else {
               label = dayName;
             }


### PR DESCRIPTION
In `one_room_all_days` mode, the label contained the current day, which made no sense. Only the room label is displayed now. Kept `roomLabel` value in the string template, in case `roomLabel` would be anything else than a string object.